### PR TITLE
Fixing MySQL insert for duplicate `django_site`.

### DIFF
--- a/tutordiscovery/templates/discovery/hooks/discovery/init
+++ b/tutordiscovery/templates/discovery/hooks/discovery/init
@@ -2,7 +2,6 @@ make migrate
 
 # Development partners
 ./manage.py create_or_update_partner  \
-  --site-id 1 \
   --site-domain {{ DISCOVERY_HOST }}:8381 \
   --code dev --name "Open edX - development" \
   --lms-url="http://lms:8000" \
@@ -12,7 +11,6 @@ make migrate
 
 # Production partner
 ./manage.py create_or_update_partner  \
-  --site-id 2 \
   --site-domain {{ DISCOVERY_HOST }} \
   --code openedx --name "Open edX" \
   --lms-url="http://lms:8000" \


### PR DESCRIPTION
When this plugin tries to call the `create_or_update_partner` command it fails because a `django_site` with id = 1 already exists. This is because the hawthorn data already had a record with id = 1 and when the plugin performs an init it tries to create a new partner with site=1 and throws an duplicate id error.