### PR TITLE
Disabled the `update_index` management command from being run on init.

### DIFF
--- a/tutordiscovery/templates/discovery/hooks/discovery/init
+++ b/tutordiscovery/templates/discovery/hooks/discovery/init
@@ -19,4 +19,4 @@ make migrate
   --organizations-api-url "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/api/organizations/v1/"
 
 ./manage.py refresh_course_metadata --partner_code=openedx
-./manage.py update_index --disable-change-limit
+# ./manage.py update_index --disable-change-limit


### PR DESCRIPTION
Received the following error on `min_effort (bigint)` values. It doesn't matter the value 0 .. N but it's more about serializing a bigint to datetime format.

  File "/openedx/venv/lib/python3.8/site-packages/elasticsearch/serializer.py", line 116, in default
    raise TypeError("Unable to serialize %r (type: %s)" % (data, type(data)))
TypeError: Unable to serialize datetime.timedelta(microseconds=1000) (type: <class 'datetime.timedelta'>)